### PR TITLE
Finish initial ECS implementation

### DIFF
--- a/BeefSpace.toml
+++ b/BeefSpace.toml
@@ -1,2 +1,5 @@
 FileVersion = 1
-Projects = {SteelEngine = {Path = "Engine"}, SteelEditor = {Path = "Editor"}, glfw-beef = {Path = "Libs/GLFW"}}
+Projects = {SteelEngine = {Path = "Engine"}, SteelEditor = {Path = "Editor"}, glfw-beef = {Path = "Libs/GLFW"}, BasicSteelGame = {Path = "Examples/BasicSteelGame"}}
+
+[Workspace]
+StartupProject = "BasicSteelGame"

--- a/Editor/src/Program.bf
+++ b/Editor/src/Program.bf
@@ -1,0 +1,14 @@
+using System;
+
+namespace SteelEditor
+{
+	class Program
+	{
+		public static int Main(String[] args)
+		{
+			Console.WriteLine("Hello Steel Editor user!");
+
+			return 0;
+		}
+	}
+}

--- a/Engine/src/ECS/Components/BaseComponent.bf
+++ b/Engine/src/ECS/Components/BaseComponent.bf
@@ -1,0 +1,48 @@
+using System;
+
+namespace SteelEngine.ECS.Components
+{
+    /// <summary>
+    /// Abstract class defining all Components.
+    /// A class derived from Component will be managed by an appropriate <see cref="SteelEngine.ECS.Systems.System"/>.
+    /// </summary>
+    public abstract class BaseComponent
+    {
+        public this(bool isEnabled = true, Entity parent = null)
+        {
+            Id = GetNextId();
+            IsEnabled = isEnabled;
+            Parent = parent;
+        }
+
+        /// <summary>
+        /// Unique identifier for the Component.
+        /// </summary>
+        public uint64 Id { get; private set; }
+
+        /// <summary>
+        /// Enabled Components are managed by their corresponding <see cref="SteelEngine.ECS.Systems.System"/>, otherwise the Component is ignored.
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Uninitialized Components are initialized by their corresponding <see cref="SteelEngine.ECS.Systems.System"/>,
+        /// otherwise the Component is initialized on the next <see cref="SteelEngine.ECS.Systems.System.Initialize"/>, <see cref="SteelEngine.ECS.Systems.System.PreUpdate"/>, or <see cref="SteelEngine.ECS.Systems.System.PostUpdate"/> methods.
+        /// </summary>
+        public bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Each Component belongs to a <see cref="SteelEngine.ECS.Entity"/> and maintains a reference to the parent <see cref="SteelEngine.ECS.Entity"/>.
+        /// </summary>
+        public Entity Parent { get; set; }
+
+        public bool IsQueuedForDeletion { get; set; }
+
+		private static uint64 _nextId = 0;
+
+		private static uint64 GetNextId()
+		{
+			return _nextId++;
+		}
+    }
+}

--- a/Engine/src/ECS/Components/BehaviorComponent.bf
+++ b/Engine/src/ECS/Components/BehaviorComponent.bf
@@ -1,0 +1,7 @@
+namespace SteelEngine.ECS.Components
+{
+	public abstract class BehaviorComponent : BaseComponent
+	{
+		public abstract void Update(float delta);
+	}
+}

--- a/Engine/src/ECS/Components/Drawable3dComponent.bf
+++ b/Engine/src/ECS/Components/Drawable3dComponent.bf
@@ -1,0 +1,6 @@
+namespace SteelEngine.ECS.Components
+{
+	public class Drawable3dComponent : BaseComponent
+	{
+	}
+}

--- a/Engine/src/ECS/Components/Physics2dComponent.bf
+++ b/Engine/src/ECS/Components/Physics2dComponent.bf
@@ -1,0 +1,6 @@
+namespace SteelEngine.ECS.Components
+{
+	public class Physics2dComponent : BaseComponent
+	{
+	}
+}

--- a/Engine/src/ECS/Components/Physics3dComponent.bf
+++ b/Engine/src/ECS/Components/Physics3dComponent.bf
@@ -1,0 +1,6 @@
+namespace SteelEngine.ECS.Components
+{
+	public class Physics3dComponent : BaseComponent
+	{
+	}
+}

--- a/Engine/src/ECS/Components/SoundComponent.bf
+++ b/Engine/src/ECS/Components/SoundComponent.bf
@@ -1,0 +1,6 @@
+namespace SteelEngine.ECS.Components
+{
+	public class SoundComponent : BaseComponent
+	{
+	}
+}

--- a/Engine/src/ECS/Components/SpriteComponent.bf
+++ b/Engine/src/ECS/Components/SpriteComponent.bf
@@ -1,0 +1,6 @@
+namespace SteelEngine.ECS.Components
+{
+	public class SpriteComponent : BaseComponent
+	{
+	}
+}

--- a/Engine/src/ECS/Components/TextComponent.bf
+++ b/Engine/src/ECS/Components/TextComponent.bf
@@ -1,0 +1,6 @@
+namespace SteelEngine.ECS.Components
+{
+	public class TextComponent : BaseComponent
+	{
+	}
+}

--- a/Engine/src/ECS/Entity.bf
+++ b/Engine/src/ECS/Entity.bf
@@ -1,0 +1,92 @@
+using System;
+using System.Collections;
+using SteelEngine.ECS.Components;
+using SteelEngine.ECS.Systems;
+
+namespace SteelEngine.ECS
+{
+	/// <summary>
+	/// Represents a collection of <see cref="SteelEngine.ECS.BaseComponent"/> objects tracked by the relevant <see cref="SteelEngine.ECS.Systems.System"/> objects.
+	/// </summary>
+	public class Entity
+	{
+	    /// <param name="game">Reference to current <see cref="SteelEngine.Application"/> instance.</param>
+	    public this(Application app)
+	    {
+	        Id = GetNextId();
+	        IsEnabled = true;
+			App = app;
+	    }
+
+		static this()
+		{
+			EntityStore = new Dictionary<uint64, Entity>();
+		}
+
+		public static Dictionary<uint64, Entity> EntityStore { get; private set; }
+
+		public Application App { get; private set; }
+
+	    /// <summary>
+	    /// Unique identifier for the Entity.
+	    /// </summary>
+	    public uint64 Id { get; private set; }
+
+	    /// <summary>
+	    /// Whether or not the Entity and all child Components should be drawn or updated.
+	    /// </summary>
+	    public bool IsEnabled { get; set; }
+
+	    #region Member Methods
+	    /// <summary>
+	    /// Adds a <see cref="SteelEngine.ECS.BaseComponent"/> to the relevant <see cref="SteelEngine.ECS.Systems.System"/>. <see cref="AddComponent(Component)"/> will also remove the <see cref="SteelEngine.ECS.BaseComponent"/> from any Entity and <see cref="SteelEngine.ECS.Systems.System"/> it was attached to before.
+	    /// </summary>
+	    /// <param name="component"><see cref="SteelEngine.ECS.Components.BaseComponent"/> to add.</param>
+	    public bool AddComponent(BaseComponent component)
+	    {
+			if (component.Parent != null)
+			{
+				if (component.Parent.Id == this.Id)
+				{
+					return false;
+				}
+				//Game.RemoveComponent(component);
+			}
+			component.Parent = this;
+	        //return Game.AddComponent(component);
+			return false;
+	    }
+
+	    /// <summary>
+	    /// Removes an individual <see cref="SteelEngine.ECS.BaseComponent"/> from this Entity's <see cref="Components"/>.
+	    /// </summary>
+	    /// <param name="component"><see cref="SteelEngine.ECS.BaseComponent"/> to remove.</param>
+	    /// <returns>Whether or not the <see cref="SteelEngine.ECS.BaseComponent"/> was removed from this Entity's <see cref="Components"/>. Will return false if the <see cref="SteelEngine.ECS.BaseComponent"/> is not present in <see cref="Components"/>.</returns>
+	    public bool RemoveComponent(BaseComponent component)
+	    {
+			if (component.Parent == null || component.Parent.Id != this.Id)
+			{
+				return false;
+			}
+	        //return Game.RemoveComponent(component);
+			return false;
+	    }
+
+		private static uint64 _nextId = 0;
+
+		private static uint64 GetNextId()
+		{
+			return _nextId++;
+		}
+
+		public ~this()
+		{
+			App.[Friend]DeleteComponentsOfEntity(this);
+		}
+
+		static ~this()
+		{
+			delete EntityStore;
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/BaseSystem.bf
+++ b/Engine/src/ECS/Systems/BaseSystem.bf
@@ -1,0 +1,125 @@
+using System.Collections;
+using SteelEngine.ECS.Components;
+
+namespace SteelEngine.ECS.Systems
+{
+	/// <summary>
+	/// Defines the abstract classes for all <see cref="SteelEngine.ECS.Systems"/> classes.
+	/// </summary>
+	public abstract class BaseSystem<T> where T : BaseComponent, delete
+	{
+		protected this(Application app)
+		{
+			App = app;
+			Components = new Dictionary<uint64, T>();
+			_uninitializedComponents = new Queue<T>();
+		}
+
+	    /// <summary>
+	    /// All tracked components.
+	    /// </summary>
+	    public Dictionary<uint64, T> Components ~ delete _;
+
+	    /// <summary>
+	    /// Reference to current <see cref="SteelEngine.Application"/> instance.
+	    /// </summary>
+	    public Application App { get; protected set; }
+
+	    /// <summary>
+	    /// Whether or not the System has called <see cref="Initialize()"/>.
+	    /// </summary>
+	    public bool IsInitialized { get; protected set; }
+
+		public T GetComponent(uint64 id)
+		{
+			T component = ?;
+			uint64 matchKey = ?;
+			Components.TryGet(id, out matchKey, out component);
+			return component;
+		}
+
+	    public virtual void Initialize()
+		{
+			if (IsInitialized)
+			{
+				return;
+			}
+			InitializeComponents();
+			IsInitialized = true;
+		}
+
+		public void InitializeComponents()
+		{
+			while (_uninitializedComponents.Count != 0)
+			{
+				Initialize(_uninitializedComponents.Dequeue());
+			}
+		}
+
+		protected abstract void Initialize(T component);
+
+		/// <summary>
+		/// Tracks all potentially uninitialized <see cref="SteelEngine.ECS.BaseComponent"/> objects.
+		/// All <see cref="SteelEngine.ECS.BaseComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+		/// </summary>
+		protected Queue<T> _uninitializedComponents ~ delete _;
+
+		/// <summary>
+		/// Adds a <see cref="SteelEngine.ECS.BaseComponent"/> to relevant <see cref="Components"/>. If the <see cref="SteelEngine.ECS.BaseComponent"/> is not initialized, it will be queued for initialization.
+		/// </summary>
+		/// <param name="componentToAdd"><see cref="SteelEngine.ECS.BaseComponent"/> to add.</param>
+		/// <returns>Whether or not the <see cref="SteelEngine.ECS.BaseComponent"/> was added to this BehaviorSystem's <see cref="Components"/>. Returns false if the <see cref="SteelEngine.ECS.BaseComponent"/> already existed.</returns>
+		protected virtual bool AddComponent(T component)
+		{
+			if (!component.IsInitialized)
+			{
+			    _uninitializedComponents.Enqueue(component);
+			}
+			if (Components.ContainsKey(component.Id))
+			{
+			    return false;
+			}
+			Components[component.Id] = component;
+			return true;
+		}
+
+		protected virtual bool RemoveComponent(T component)
+		{
+			return RemoveComponent(component.Id);
+		}
+
+		protected virtual bool RemoveComponent(uint64 componentId)
+		{
+			return Components.Remove(componentId);
+		}
+
+		// This current method for deletion requires that a component only be registered to one system at a time.
+		// This means that for custom systems, only BehaviorComponents should ever be deleted.
+		// This is reasonable to assume, as the base engine components for rendering, sound, and physics should not participate in custom systems.
+		// By leaving this virtual, the object lifetime can be managed differently in custom systems.
+		protected virtual void DeleteComponents(bool onlyDeletionQueuedComponents = true)
+		{
+			let componentsToDelete = new List<T>();
+			defer delete componentsToDelete;
+			for (let item in Components)
+			{
+				let component = item.value;
+				if (!onlyDeletionQueuedComponents || component.IsQueuedForDeletion)
+				{
+					componentsToDelete.Add(component);
+				}
+			}
+
+			for (let component in componentsToDelete)
+			{
+				delete component;
+				RemoveComponent(component.Id);
+			}
+		}
+
+		public ~this()
+		{
+			DeleteComponents(false);
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/BehaviorSystem.bf
+++ b/Engine/src/ECS/Systems/BehaviorSystem.bf
@@ -1,0 +1,34 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class BehaviorSystem : BaseSystem<BehaviorComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		public override void Initialize()
+		{
+			base.Initialize();
+		}
+
+		protected override void Initialize(BehaviorComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Update(float delta)
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				let component = item.value;
+				if (component.IsEnabled)
+				{
+					component.Update(delta);
+				}
+			}
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/Physics2dSystem.bf
+++ b/Engine/src/ECS/Systems/Physics2dSystem.bf
@@ -1,0 +1,34 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class Physics2dSystem : BaseSystem<Physics2dComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		public override void Initialize()
+		{
+			base.Initialize();
+		}
+
+		protected override void Initialize(Physics2dComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Update(float delta)
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				UpdateComponent(item.value, delta);
+			}
+		}
+
+		private void UpdateComponent(Physics2dComponent component, float delta)
+		{
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/Physics3dSystem.bf
+++ b/Engine/src/ECS/Systems/Physics3dSystem.bf
@@ -1,0 +1,34 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class Physics3dSystem : BaseSystem<Physics3dComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		public override void Initialize()
+		{
+			base.Initialize();
+		}
+
+		protected override void Initialize(Physics3dComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Update(float delta)
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				UpdateComponent(item.value, delta);
+			}
+		}
+
+		private void UpdateComponent(Physics3dComponent component, float delta)
+		{
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/Render3dSystem.bf
+++ b/Engine/src/ECS/Systems/Render3dSystem.bf
@@ -1,0 +1,29 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class Render3DSystem : BaseSystem<Drawable3dComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		protected override void Initialize(Drawable3dComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Draw()
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				DrawComponent(item.value);
+			}
+		}
+
+		private void DrawComponent(Drawable3dComponent component)
+		{
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/RenderSpriteSystem.bf
+++ b/Engine/src/ECS/Systems/RenderSpriteSystem.bf
@@ -1,0 +1,29 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class RenderSpriteSystem : BaseSystem<SpriteComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		protected override void Initialize(SpriteComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Draw()
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				DrawComponent(item.value);
+			}
+		}
+
+		private void DrawComponent(SpriteComponent component)
+		{
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/RenderTextSystem.bf
+++ b/Engine/src/ECS/Systems/RenderTextSystem.bf
@@ -1,0 +1,29 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class RenderTextSystem : BaseSystem<TextComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		protected override void Initialize(TextComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Draw()
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				DrawComponent(item.value);
+			}
+		}
+
+		private void DrawComponent(TextComponent component)
+		{
+		}
+	}
+}

--- a/Engine/src/ECS/Systems/SoundSystem.bf
+++ b/Engine/src/ECS/Systems/SoundSystem.bf
@@ -1,0 +1,29 @@
+using SteelEngine.ECS.Components;
+using System.Collections;
+using System;
+
+namespace SteelEngine.ECS.Systems
+{
+	public class SoundSystem : BaseSystem<SoundComponent>
+	{
+		public this(Application app) : base(app) {}
+
+		protected override void Initialize(SoundComponent component)
+		{
+			component.[Friend]IsInitialized = true;
+		}
+
+		public void Update(float delta)
+		{
+			InitializeComponents();
+			for (let item in Components)
+			{
+				UpdateComponent(item.value, delta);
+			}
+		}
+
+		private void UpdateComponent(SoundComponent component, float delta)
+		{
+		}
+	}
+}


### PR DESCRIPTION
ECS is split into Entities, Components, and Systems.

Systems manage all of the Components relevant to their Update or Draw
cycle. Each Component is registered to a "Parent" Entity. Entities are
little more than an ID, providing helper methods to interact with the
relevant Components. These helper methods are expensive to call, but the
use case would be that on a BehaviorComponent initialization, the
necessary Components would be retrieved via these slow helper methods.

Systems manage the lifetimes of Components. When an Entity is deleted,
all of the Components are queued up for deletion. On the next Update
cycle, each System will delete whatever components it has queued up for
deletion.

When the Application closes down, all of the Entities are unregistered
and the Components are immediately deleted.